### PR TITLE
Fix error in installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ### Powercord
 
-1. clone the repo `cd powercord/src/powercord/themes && git clone https://github.com/x6r/dracula`
+1. clone the repo `cd powercord/src/Powercord/themes && git clone https://github.com/x6r/dracula`
 2. enable dracula by typing `[p]theme enable dracula` ([Theme Toggler](https://github.com/redstonekasi/theme-toggler))
 
 ### BetterDiscord


### PR DESCRIPTION
The folder inside `src` in the Powercord repo seems to have a capital P, so I've changed it to match.